### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,37 +8,37 @@
 
 WiFiConnect	KEYWORD1
 WiFiConnectOLED	KEYWORD1
-WiFiConnetparam KEYWORD1
+WiFiConnetparam	KEYWORD1
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-startConfigurationPortal KEYWORD2
-startParamsPortal KEYWORD2
-addParameter KEYWORD2
-setAPName KEYWORD2
-getAPName  KEYWORD2
-resetSettings KEYWORD2
-autoConnect KEYWORD2
-setAPStaticIPConfig KEYWORD2
-setSTAStaticIPConfig KEYWORD2
-setAPCallback KEYWORD2
-setSaveConfigCallback KEYWORD2
-setDebug KEYWORD2
-setRetryAttempts KEYWORD2
-setConnectionTimeoutSecs KEYWORD2
-setAPModeTimeoutMins KEYWORD2
-statusToString KEYWORD2
-getRSSIasQuality KEYWORD2
-isIp KEYWORD2
-toStringIp KEYWORD2
-displayTurnOFF KEYWORD2
-displayLoop KEYWORD2
-displayON KEYWORD2
+startConfigurationPortal	KEYWORD2
+startParamsPortal	KEYWORD2
+addParameter	KEYWORD2
+setAPName	KEYWORD2
+getAPName	KEYWORD2
+resetSettings	KEYWORD2
+autoConnect	KEYWORD2
+setAPStaticIPConfig	KEYWORD2
+setSTAStaticIPConfig	KEYWORD2
+setAPCallback	KEYWORD2
+setSaveConfigCallback	KEYWORD2
+setDebug	KEYWORD2
+setRetryAttempts	KEYWORD2
+setConnectionTimeoutSecs	KEYWORD2
+setAPModeTimeoutMins	KEYWORD2
+statusToString	KEYWORD2
+getRSSIasQuality	KEYWORD2
+isIp	KEYWORD2
+toStringIp	KEYWORD2
+displayTurnOFF	KEYWORD2
+displayLoop	KEYWORD2
+displayON	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-OLEDDISPLAY_DEFAULTFONT LITERAL1
+OLEDDISPLAY_DEFAULTFONT	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
